### PR TITLE
Add support for a single line chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "npm-run-all": "4.1.5",
     "prettier": "2.7.1"
   },
-  "version": "0.0.7"
+  "version": "0.0.8"
 }

--- a/packages/ember-apache-echarts/package.json
+++ b/packages/ember-apache-echarts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-apache-echarts",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Echarts for Ember",
   "keywords": [
     "ember-addon"
@@ -79,11 +79,13 @@
     "main": "addon-main.js",
     "app-js": {
       "./components/chart/bar.js": "./dist/_app_/components/chart/bar.js",
+      "./components/chart/line.js": "./dist/_app_/components/chart/line.js",
       "./components/chart/pie.js": "./dist/_app_/components/chart/pie.js",
       "./components/chart/time-series.js": "./dist/_app_/components/chart/time-series.js",
       "./helpers/css-size.js": "./dist/_app_/helpers/css-size.js",
       "./modifiers/abstract-chart.js": "./dist/_app_/modifiers/abstract-chart.js",
       "./modifiers/bar-chart.js": "./dist/_app_/modifiers/bar-chart.js",
+      "./modifiers/line-chart.js": "./dist/_app_/modifiers/line-chart.js",
       "./modifiers/pie-chart.js": "./dist/_app_/modifiers/pie-chart.js",
       "./modifiers/time-series-chart.js": "./dist/_app_/modifiers/time-series-chart.js",
       "./utils/create-lookup.js": "./dist/_app_/utils/create-lookup.js",

--- a/packages/ember-apache-echarts/src/components/chart/line.hbs
+++ b/packages/ember-apache-echarts/src/components/chart/line.hbs
@@ -1,0 +1,19 @@
+<div {{did-insert this.setup}}>
+  <div
+    ...attributes
+    {{style width=(css-size @width "100%") height=(css-size @height 400)}}
+    {{line-chart
+      this.args
+      tooltipFormatter=(if (has-block "itemTooltip") this.tooltipFormatter)
+    }}
+  ></div>
+
+  {{#if (has-block "itemTooltip")}}
+    <div
+      data-role="itemTooltip"
+      style={{html-safe (if this.tooltipItem "" "display: none")}}
+    >
+      {{yield this.tooltipItem to="itemTooltip"}}
+    </div>
+  {{/if}}
+</div>

--- a/packages/ember-apache-echarts/src/components/chart/line.js
+++ b/packages/ember-apache-echarts/src/components/chart/line.js
@@ -1,0 +1,61 @@
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import Component from '@glimmer/component';
+import pick from 'lodash/pick';
+
+/**
+ * Converts an EChart tooltip param into a standardized & simplied object this
+ * component can yield to custom tooltip components.
+ *
+ * The object returned from this function includes the following properties:
+ *
+ * `label`
+ * : The label used for the pie slice.
+ *
+ * `value`
+ * : The value used for the pie slice.
+ *
+ * `marker`
+ * : Raw HTML that renders the marker used to identify the item on the chart.
+ *
+ * `dataIndex`
+ * : The index of the item in the data for the series this item belongs to.
+ *
+ * `data`
+ * : The data object from the chart data for this item.
+ *
+ * `slice`
+ * : An object representing the graphical properties of the slice: `color` and
+ *   `percent` of circle.
+ */
+const toTooltipItem = (param) => ({
+  ...pick(param, 'value', 'marker', 'data', 'dataIndex'),
+  label: param.name,
+  slice: pick(param, 'color', 'percent'),
+
+  // TODO: Think about how/if we need to support multiple series for pie charts.
+  //       [twl 30.Apr.22]
+  //
+  // series: {
+  //   ...dataset[param.seriesIndex],
+  //   index: param.seriesIndex,
+  // },
+});
+
+export default class LineChartComponent extends Component {
+  itemTooltipElement;
+
+  @tracked tooltipItem;
+
+  @action
+  setup(element) {
+    this.itemTooltipElement = element.querySelector('[data-role=itemTooltip]');
+  }
+
+  @action
+  tooltipFormatter(params) {
+    this.tooltipItem = toTooltipItem(params);
+
+    return this.itemTooltipElement;
+  }
+}

--- a/packages/ember-apache-echarts/src/modifiers/line-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/line-chart.js
@@ -1,0 +1,125 @@
+import AbstractChartModifier from './abstract-chart';
+
+// TODO: Import only the required components to keep the bundle size small. See
+//       https://echarts.apache.org/handbook/en/basics/import/ [twl 6.Apr.22]
+
+/**
+ * Renders one or more line charts.
+ *
+ * # Arguments
+ *
+ * `chartStyle`
+ * : CSS properties for the entire chart including background color, border,
+ *   margins and padding.
+ *
+ * `chartTitleStyle`
+ * : CSS properties for the title for the entire chart including color, font,
+ *   background color, border and alignment.
+ *
+ * `cellStyle`
+ * : CSS properties defining the style for individual plots when rendering more
+ *   than one series
+ *
+ * `cellTitleStyle`
+ * : CSS properties defining the style for the titles for individual plots when
+ *   rendering more than one series
+ *
+ * `maxColumns`
+ * : The maximum number of columns to render when rendering more than one series
+ *
+ * `onSelect`
+ * : Called when an element on a chart is selected
+ *
+ * `tooltipFormatter`
+ * : The function used to generate the tool tip
+ *
+ * `smooth`
+ * : Whether to render a `smooth` or a `line`
+ * 
+ * `type`
+ * : https://echarts.apache.org/en/option.html#xAxis.type
+ */
+export default class LineChartModifier extends AbstractChartModifier {
+  configureChart(args, chart) {
+    const allSeries = args.series ?? [{ data: args.data }];
+    const { tooltipFormatter, onSelect } = args;
+    const { config } = this.buildLayout(args, chart);
+
+    chart.setOption({
+      ...config,
+      tooltip: {
+        formatter: tooltipFormatter,
+      },
+    });
+
+    chart.handle('selectchanged', (event) => {
+      const { fromAction, fromActionPayload, isFromClick } = event;
+
+      if (!isFromClick) {
+        return;
+      }
+
+      const seriesIndex = fromActionPayload.seriesIndex;
+      const dataIndex = fromActionPayload.dataIndexInside;
+      const series = allSeries[seriesIndex];
+      const name = series.data[dataIndex] ? series.data[dataIndex].name : null;
+
+      if (name) {
+        chart.dispatchAction({
+          type: fromAction,
+          name,
+        });
+      }
+
+      onSelect && onSelect(fromAction === 'select' ? name : null);
+    });
+  }
+
+  /**
+   * Generates the plot config for a single plot on this chart.
+   */
+  generatePlotConfig(series, layout, context) {
+    const { smooth = true, noDataText, xType = 'category', yType = 'value' } = context.args;
+
+    return (!series.data || series.data.length == 0) && noDataText
+      ? undefined
+      : {
+          xAxis: {
+            xType,
+            data: series.data.map((e) => e.x),
+          },
+          yAxis: {
+            type: yType,
+          },
+          series: [
+            {
+              type: 'line',
+              smooth,
+              // if this is changed, update the select handler below
+              selectedMode: 'single',
+              data: series.data.map((e) => e.y),
+            },
+          ],
+        };
+  }
+
+  /**
+   * Generates text to overlay on each cell of the chart, if any.
+   */
+  generateTextOverlayConfig(series, args, layout, style) {
+    const { noDataText } = args;
+
+    return (!series.data || series.data.length == 0) && noDataText
+      ? this.generateTextConfig(
+          noDataText,
+          {
+            width: layout.innerWidth,
+            height: layout.innerHeight,
+            x: layout.innerX,
+            y: layout.innerY,
+          },
+          style
+        )
+      : undefined;
+  }
+}

--- a/packages/test-app/app/components/chart-line-example.hbs
+++ b/packages/test-app/app/components/chart-line-example.hbs
@@ -1,0 +1,8 @@
+<h2>Simple Line Chart</h2>
+<Chart::Line
+  class="border"
+  @width="100%"
+  @height="500"
+  @data={{this.chartData}}
+  @noDataText="No data"
+/>

--- a/packages/test-app/app/components/chart-line-example.js
+++ b/packages/test-app/app/components/chart-line-example.js
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+
+export default class ChartLineExample extends Component {
+  chartData = [
+    {
+      x: '2020-01-01',
+      y: 6126,
+    },
+    {
+      x: '2020-02-01',
+      y: 100.88,
+    },
+    {
+      x: '2020-03-01',
+      y: 4953,
+    },
+    {
+      x: '2020-04-01',
+      y: 4678,
+    },
+    {
+      x: '2020-05-01',
+      y: 4321,
+    },
+    {
+      x: '2020-06-01',
+      y: 3952,
+    },
+  ];
+}

--- a/packages/test-app/app/templates/application.hbs
+++ b/packages/test-app/app/templates/application.hbs
@@ -1,3 +1,5 @@
 <h2 id="title">Welcome to ember-apache-echarts</h2>
 
 <ChartPieExample />
+
+<ChartLineExample />


### PR DESCRIPTION
This basically copies the pie chart code and modifies it to become a line chart. Rather than `value` and `at` I used `x` and `y` because it will not always be time based data. How to standardize around this could use some discussion. 

It's not entirely clear to me how to add support for multilines. I was able to test making one by adding two series to the component, but not sure how to make that an argument. I think time series does this, but calling it time series seems weird.

This would solve my immediate need of a single line chart. 