### PR TITLE
Enhance bar chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ cd <project-root>
 npm link ember-apache-echarts
 ```
 
-To unlink this project:
+Or for `yarn`:
+
+```
+cd packages/ember-apache-echarts/
+yarn link
+
+cd <project-root>
+yarn link ember-apache-echarts
+```
+
+To unlink this project via `npm`:
 
 ```
 cd <project-root>
@@ -45,7 +55,18 @@ npm unlink --no-save ember-apache-echarts
 
 cd packages/ember-apache-echarts/
 npm unlink
+```
 
+To unlink this project via `yarn`:
+
+```
+cd packages/ember-apache-echarts/
+yarn unlink
+
+cd <project-root>
+yarn unlink ember-apache-echarts
+yarn install --check-files
+// or yarn install --force
 ```
 
 Note that after unlinking, you may need to delete `node_modules` and reinstall

--- a/packages/ember-apache-echarts/docs/architecture.md
+++ b/packages/ember-apache-echarts/docs/architecture.md
@@ -1,0 +1,127 @@
+Chart Architecture
+==================
+
+Each chart is composed of an Ember component and a modifier that is used to
+render the chart into that component.
+
+The chart components serve two purposes:
+
+ - **Determine Chart Size**
+   Each chart component renders a `div` whose size determines the size of the
+   chart instance rendered within that `div`. A resize observer monitors changes
+   to this `div` and resizes the chart accordingly.
+
+ - **Render Custom Tooltips**
+   Tooltips are rendered via named blocks, allowing the end user of the chart to
+   define custom toolips. Once activated, the tooltips are removed from the
+   container `div` and absolutely positioned over the appropriate place on the
+   chart.
+
+Each chart component also has a modifier that performs the work of creating and
+rendering the chart via Apache eCharts.
+
+
+### Modifier Architecture
+
+Since Apache eCharts does not have a full layout engine, `AbstractChartModifier`
+provides a primitive one, along with other capabilities like monitoring resize
+events on its corresponding component and managing event listeners on the chart.
+
+The layout engine enables positioning the data zoom, legend, title and other
+chart parts automatically, so manual positioning or style-specific calculations
+are not required.
+
+The Apache eChart configuration for the chart is built via the `buildLayout`
+method, which is used to progressively add configuration sections to an object
+that is eventually passed as the `options` for the chart.
+
+Conceptually, `buildLayout` works by creating a layout context, then
+sequentially calling methods to build the different parts of the chart from the
+outside inward. This is the "build pipeline".
+
+Currently, the default build pipeline consists of the following steps:
+
+ - *Chart Box*: The background, border, margin & padding for the entire chart
+ - *Title*: The title of the chart, if any
+ - *Legend*: The legend of the chart, if any
+ - *Cell Boxes*: The background, border, margin & padding for each of the plots
+   used it this chart. By default, when multiple series are provided as data,
+   the chart is rendered using "small multiples", with one chart per series
+ - *Cell Titles*: The title for each plot, taken from the series name, if any
+ - *Cell Plots*: The chart plots themselves
+ - *Cell Text Overlays*: Text overlaid on top of each plot, such as "No Data"
+   text when no data is provided or no data exists for a specific series
+
+As mentioned, this order adds parts from the outside inward. If you imagine that
+the chart box is the outermost rectangle, then the title, legend and cell boxes
+exist as rectangles within that rectangle and the cell titles and cell plots
+exist as rectangles within each cell (the text overlays are a layer on top of
+the cell plots' rectangles).
+
+As each part of the chart is added to the configuration, the layout context is
+adjusted to account for the remaining area in the chart that is available to
+be used by the parts further along the build pipeline.
+
+For instance, if the chart is 800 x 600 and a 20 pixel high title is rendered at
+the top of the chart at position 0, 0, then the layout context used when adding
+the legend will be 800 x 580 at the position 0, 20.
+
+The reduction in render area for each part takes into account not only the space
+required to render the core content, but any margin, padding and border applied
+to that part. (Though, because the metrics for the core content are calculated
+by the layout algorithm without access to the actual render metrics, this can
+sometimes be off by a few pixels, so it's best not to lay things out too
+tightly).
+
+
+#### `addXXX` vs `generateXXXConfig` methods
+
+Each of the steps in the build pipline calls an `addXXX` method whose job is to
+add one part of the chart to a configuration object (the Apache eCharts
+`options` object) and return an adjusted layout (the change to `config` is a
+side effect of each of these methods; it is not returned).
+
+These methods in turn call a `generateXXXConfig` method that generates the
+actual Apache eCharts configuration.
+
+Roughly, the `add` methods map to the layout framework described above, while
+the `generate` methods map to the Apache eCharts options.
+
+
+### Configuring Styles
+
+The rendering styles on the chart are defined using CSS properties passed in via
+a styles argument. Each part of the chart has its own styles argument.
+
+For instance, the following configures the cell for each plot to have a solid
+border and a margin of 2.
+
+```
+<Chart::Bar
+  ...
+  @cellStyle={{hash border="solid 1px rgb(229, 231, 235)" margin=2}}
+  ...
+/>
+```
+
+Each style is merged with a default style defined by the `defaultStyles`
+property of either `AbstractChartModifier` or a modifer for a specific chart
+type. Default styles set the font, margins and text alignment to reasonable
+values so these don't have to be specified for every chart part.
+
+
+### Small Multiple Charts
+
+By default, multiple data series are rendered as separate plots, one for each
+data series. Individual chart types may override this on a type or variant
+basis.
+
+For example, the `BarChart` overrides this for its stacked and grouped variants.
+
+While multiple chart components could be used to render multiple data series,
+using the small multiples functionality provides the added benefit of syncing
+colors and filters across all plots, and rendering a single, global legend.
+
+When using small multiples, the `maxColumns` argument determines how many charts
+to render in each row. When the number of data series exceeds this number,
+multiple rows are created.

--- a/packages/ember-apache-echarts/package.json
+++ b/packages/ember-apache-echarts/package.json
@@ -88,6 +88,8 @@
       "./modifiers/time-series-chart.js": "./dist/_app_/modifiers/time-series-chart.js",
       "./utils/create-lookup.js": "./dist/_app_/utils/create-lookup.js",
       "./utils/data/compute-statistic.js": "./dist/_app_/utils/data/compute-statistic.js",
+      "./utils/data/get-series-data.js": "./dist/_app_/utils/data/get-series-data.js",
+      "./utils/data/get-series-totals.js": "./dist/_app_/utils/data/get-series-totals.js",
       "./utils/data/get-unique-dataset-values.js": "./dist/_app_/utils/data/get-unique-dataset-values.js",
       "./utils/layout/compute-inner-box.js": "./dist/_app_/utils/layout/compute-inner-box.js",
       "./utils/layout/compute-max-text-metrics.js": "./dist/_app_/utils/layout/compute-max-text-metrics.js",

--- a/packages/ember-apache-echarts/package.json
+++ b/packages/ember-apache-echarts/package.json
@@ -91,6 +91,7 @@
       "./utils/data/get-series-data.js": "./dist/_app_/utils/data/get-series-data.js",
       "./utils/data/get-series-totals.js": "./dist/_app_/utils/data/get-series-totals.js",
       "./utils/data/get-unique-dataset-values.js": "./dist/_app_/utils/data/get-unique-dataset-values.js",
+      "./utils/data/rotate-data-series.js": "./dist/_app_/utils/data/rotate-data-series.js",
       "./utils/layout/compute-inner-box.js": "./dist/_app_/utils/layout/compute-inner-box.js",
       "./utils/layout/compute-max-text-metrics.js": "./dist/_app_/utils/layout/compute-max-text-metrics.js",
       "./utils/layout/compute-text-height.js": "./dist/_app_/utils/layout/compute-text-height.js",

--- a/packages/ember-apache-echarts/src/components/chart/bar.js
+++ b/packages/ember-apache-echarts/src/components/chart/bar.js
@@ -29,14 +29,11 @@ const toTooltipItem = (param) => ({
   ...pick(param, 'value', 'marker', 'dataIndex'),
   label: param.name,
   bar: pick(param, 'color'),
-
-  // TODO: Think about how/if we need to support multiple series for bar charts.
-  //       [twl 30.Apr.22]
-  //
-  // series: {
-  //   ...dataset[param.seriesIndex],
-  //   index: param.seriesIndex,
-  // },
+  meta: param.data?.meta,
+  series: {
+    label: param.seriesName,
+    index: param.seriesIndex,
+  },
 });
 
 export default class BarChartComponent extends Component {

--- a/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
@@ -14,7 +14,7 @@ import mergeAtPaths from '../utils/merge-at-paths';
 // composite properties or individual constituent properties
 const baseStyle = {
   border: '0px solid #000',
-  font: 'bold 16px Montserrat',
+  font: 'bold 16px Montserrat,sans-serif',
   color: '#000',
   margin: 0,
   padding: 0,
@@ -31,7 +31,7 @@ export default class AbstractChartModifier extends Modifier {
     return {
       chart: {},
       chartTitle: {
-        font: 'bold 20px Montserrat',
+        font: 'bold 20px Montserrat,sans-serif',
         textAlign: 'center',
         margin: 24,
       },
@@ -40,12 +40,12 @@ export default class AbstractChartModifier extends Modifier {
         margin: 8,
       },
       cellTitle: {
-        font: 'bold 16px Montserrat',
+        font: 'bold 16px Montserrat,sans-serif',
         textAlign: 'left',
         margin: 8,
       },
       cellTextOverlay: {
-        font: 'normal 16px Montserrat',
+        font: 'normal 16px Montserrat,sans-serif',
         textAlign: 'center',
         verticalAlign: 'middle',
         zIndex: Z_OVERLAY,

--- a/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
@@ -37,7 +37,7 @@ export default class AbstractChartModifier extends Modifier {
         textAlign: 'center',
         margin: 24,
       },
-      chartLegend: {
+      legend: {
         font: 'normal 16px Montserrat,sans-serif',
         textAlign: 'left',
         margin: 24,
@@ -254,7 +254,7 @@ export default class AbstractChartModifier extends Modifier {
       return context.layout;
     }
 
-    const style = resolveStyle(context.styles.chartLegend, context.layout);
+    const style = resolveStyle(context.styles.legend, context.layout);
 
     mergeAtPaths(config, [
       this.generateLegendConfig(

--- a/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
@@ -577,7 +577,11 @@ export default class AbstractChartModifier extends Modifier {
       //       has a border, it overlaps the chart border. [twl 2.Nov.22]
       xLayout = {
         right:
-          layout.chartWidth - layout.width - layout.x + 1 + style.marginRight +
+          layout.chartWidth -
+          layout.width -
+          layout.x +
+          1 +
+          style.marginRight +
           style.borderRightWidth / 2,
       };
     } else {
@@ -685,13 +689,15 @@ export default class AbstractChartModifier extends Modifier {
     // Divide by 2 on border, since it appears to be drawn at the end of the
     // legend rather than inside or outside the legend
     const metrics = {
-      width: style.paddingLeft +
+      width:
+        style.paddingLeft +
         style.paddingRight +
         style.borderLeftWidth / 2 +
         style.borderRightWidth / 2 +
         style.marginLeft +
         style.marginRight,
-      height: style.paddingTop +
+      height:
+        style.paddingTop +
         style.paddingBottom +
         style.borderTopWidth / 2 +
         style.borderBottomWidth / 2 +
@@ -702,27 +708,29 @@ export default class AbstractChartModifier extends Modifier {
     if (orientation === 'horizontal') {
       const labelMetrics = labels.reduce(
         (result, label) => {
-          const textMetrics = computeTextMetrics(label, style)
+          const textMetrics = computeTextMetrics(label, style);
 
           result.width += markerWidth + textMetrics.width;
           result.height = Math.max(result.height, textMetrics.height);
 
           return result;
         },
-        { width: 0, height: 0 },
+        { width: 0, height: 0 }
       );
 
       metrics.width = Math.min(
         layout.width,
-        metrics.width + labelMetrics.width + (itemGap * (labels.length - 1))
+        metrics.width + labelMetrics.width + itemGap * (labels.length - 1)
       );
       metrics.height = metrics.height + labelMetrics.height;
     } else {
       const labelMetrics = computeMaxTextMetrics(labels, style, layout.width);
 
       metrics.width = metrics.width + markerWidth + labelMetrics.width;
-      metrics.height = metrics.height + (labelMetrics.height * labels.length) +
-        (itemGap * (labels.length - 1));
+      metrics.height =
+        metrics.height +
+        labelMetrics.height * labels.length +
+        itemGap * (labels.length - 1);
     }
 
     return metrics;

--- a/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
@@ -542,7 +542,7 @@ export default class AbstractChartModifier extends Modifier {
 
     if (legend.startsWith('top') || legend.endsWith('Top')) {
       yLayout = {
-        top: layout.y + style.marginTop,
+        top: layout.y + style.marginTop + style.borderTopWidth / 2,
       };
     } else if (legend.startsWith('bottom') || legend.endsWith('Bottom')) {
       // NOTE: Not sure why I need the +1, but if it's missing and the legend
@@ -553,7 +553,8 @@ export default class AbstractChartModifier extends Modifier {
           layout.height -
           layout.y +
           1 +
-          style.marginBottom,
+          style.marginBottom +
+          style.borderBottomWidth / 2,
       };
     } else {
       // NOTE: Technically this positions the legend in the vertical center of
@@ -569,14 +570,15 @@ export default class AbstractChartModifier extends Modifier {
 
     if (legend.startsWith('left') || legend.endsWith('Left')) {
       xLayout = {
-        left: layout.x + style.marginLeft,
+        left: layout.x + style.marginLeft + style.borderLeftWidth / 2,
       };
     } else if (legend.startsWith('right') || legend.endsWith('Right')) {
       // NOTE: Not sure why I need the +1, but if it's missing and the legend
       //       has a border, it overlaps the chart border. [twl 2.Nov.22]
       xLayout = {
         right:
-          layout.chartWidth - layout.width - layout.x + 1 + style.marginRight,
+          layout.chartWidth - layout.width - layout.x + 1 + style.marginRight +
+          style.borderRightWidth / 2,
       };
     } else {
       xLayout = {

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -164,12 +164,11 @@ export default class BarChartModifier extends AbstractChartModifier {
       }),
       // If grouped or stacked, render multple series on a single chart rather
       // than one chart per series
-      series:
-        this.isStackedVariant(args.variant)
-          ? [{ data: rotateDataSeries(context.series, 'name', 'value') }]
-          : this.isGroupedVariant(args.variant)
-            ? [{ data: context.series }]
-            : context.series,
+      series: this.isStackedVariant(args.variant)
+        ? [{ data: rotateDataSeries(context.series, 'name', 'value') }]
+        : this.isGroupedVariant(args.variant)
+        ? [{ data: context.series }]
+        : context.series,
     };
   }
 
@@ -306,9 +305,9 @@ export default class BarChartModifier extends AbstractChartModifier {
         axisLabel: {
           // Ensure every category is shown on the axis
           interval: 0,
-          ...!isHorizontal && {
+          ...(!isHorizontal && {
             overflow: 'break',
-          },
+          }),
           width: xAxisLabelWidth,
           // margin between the axis label and the axis line
           margin: xAxisStyle.marginTop,

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -255,6 +255,34 @@ export default class BarChartModifier extends AbstractChartModifier {
       // if this is changed, update the select handler in `configureChart`
       selectedMode: 'single',
     };
+    const valueAxisConfig = [
+      {
+        gridIndex,
+        type: 'value',
+        max: valueAxisScale === 'shared' ? data.maxValue : 'dataMax',
+        axisLabel: {
+          // margin between the axis label and the axis line
+          margin: valueAxisStyle.marginRight,
+          ...this.generateAxisLabelConfig(layout, valueAxisStyle),
+        },
+      },
+    ];
+    const categoryAxisConfig = [
+      {
+        gridIndex,
+        type: 'category',
+        data: categories,
+        axisLabel: {
+          // Ensure every category is shown on the axis
+          interval: 0,
+          overflow: 'break',
+          width: categoryAxisLabelWidth,
+          // margin between the axis label and the axis line
+          margin: categoryAxisStyle.marginTop,
+          ...this.generateAxisLabelConfig(layout, categoryAxisStyle),
+        },
+      },
+    ];
 
     return {
       grid: [
@@ -266,34 +294,8 @@ export default class BarChartModifier extends AbstractChartModifier {
           height: layout.innerHeight - categoryAxisHeight - valueAxisOverflow,
         },
       ],
-      yAxis: [
-        {
-          gridIndex,
-          type: 'value',
-          max: valueAxisScale === 'shared' ? data.maxValue : 'dataMax',
-          axisLabel: {
-            // margin between the axis label and the axis line
-            margin: valueAxisStyle.marginRight,
-            ...this.generateAxisLabelConfig(layout, valueAxisStyle),
-          },
-        },
-      ],
-      xAxis: [
-        {
-          gridIndex,
-          type: 'category',
-          data: categories,
-          axisLabel: {
-            // Ensure every category is shown on the axis
-            interval: 0,
-            overflow: 'break',
-            width: categoryAxisLabelWidth,
-            // margin between the axis label and the axis line
-            margin: categoryAxisStyle.marginTop,
-            ...this.generateAxisLabelConfig(layout, categoryAxisStyle),
-          },
-        },
-      ],
+      yAxis: valueAxisConfig,
+      xAxis: categoryAxisConfig,
       series: !isGroupedOrStacked
         ? [
             {

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -88,12 +88,12 @@ export default class BarChartModifier extends AbstractChartModifier {
     return {
       ...styles,
       xAxis: {
-        font: 'normal 12px Montserrat',
+        font: 'normal 12px Montserrat,sans-serif',
         textAlign: 'center',
         marginTop: 8,
       },
       yAxis: {
-        font: 'normal 12px Montserrat',
+        font: 'normal 12px Montserrat,sans-serif',
         textAlign: 'right',
         // Add extra margin to the left too, since the width calculation of the
         // Y axis can sometimes be off a few pixels

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -286,7 +286,9 @@ export default class BarChartModifier extends AbstractChartModifier {
         axisLabel: {
           // Ensure every category is shown on the axis
           interval: 0,
-          overflow: 'break',
+          ...!isHorizontal && {
+            overflow: 'break',
+          },
           width: xAxisLabelWidth,
           // margin between the axis label and the axis line
           margin: xAxisStyle.marginTop,

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -158,13 +158,6 @@ export default class BarChartModifier extends AbstractChartModifier {
    * Generates the plot config for a single plot on this chart.
    */
   generatePlotConfig(series, layout, context, gridIndex) {
-    console.log(
-      '\n### generating plot config',
-      series,
-      layout,
-      context,
-      gridIndex
-    );
     const { args, styles, data } = context;
     const { noDataText, xAxisScale, yAxisScale } = args;
 

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -31,6 +31,14 @@ import AbstractChartModifier from './abstract-chart';
  * : CSS properties defining the style for the titles for individual plots when
  *   rendering more than one series
  *
+ * `xAxisStyle`
+ * : CSS properties defining the style for horizontal X axis, regardless of the
+ *   value of `orientation`
+ *
+ * `yAxisStyle`
+ * : CSS properties defining the style for vertical Y axis, regardless of the
+ *   value of `orientation`
+ *
  * `maxColumns`
  * : The maximum number of columns to render when rendering more than one series
  *
@@ -55,12 +63,12 @@ export default class BarChartModifier extends AbstractChartModifier {
 
     return {
       ...styles,
-      categoryAxis: {
+      xAxis: {
         font: 'normal 12px Montserrat',
         textAlign: 'center',
         marginTop: 8,
       },
-      valueAxis: {
+      yAxis: {
         font: 'normal 12px Montserrat',
         textAlign: 'right',
         // Add extra margin to the left too, since the width calculation of the
@@ -187,48 +195,40 @@ export default class BarChartModifier extends AbstractChartModifier {
 
     // Configure the Y axis
     // Not the real labels, but good enough for now for computing the metrics
-    const valueAxisStyle = resolveStyle(styles.valueAxis, context.layout);
-    const valueAxisLabels = values.map((value) =>
+    const yAxisStyle = resolveStyle(styles.yAxis, context.layout);
+    const yAxisLabels = values.map((value) =>
       value != null ? `${value}` : ''
     );
-    const valueAxisMetrics = computeMaxTextMetrics(
-      valueAxisLabels,
-      valueAxisStyle
-    );
-    const valueAxisWidth =
-      valueAxisMetrics.width +
-      valueAxisStyle.marginLeft +
-      valueAxisStyle.marginRight;
+    const yAxisMetrics = computeMaxTextMetrics(yAxisLabels, yAxisStyle);
+    const yAxisWidth =
+      yAxisMetrics.width + yAxisStyle.marginLeft + yAxisStyle.marginRight;
 
     // Only applies when the very top label is rendered; for now, assuming it's
     // always there, since I don't know how to determine this on the fly
-    const valueAxisTopLabelMetrics = computeTextMetrics(
-      `${maxValue}`,
-      valueAxisStyle
-    );
-    const valueAxisOverflow = valueAxisTopLabelMetrics.height / 2;
+    const yAxisTopLabelMetrics = computeTextMetrics(`${maxValue}`, yAxisStyle);
+    const yAxisOverflow = yAxisTopLabelMetrics.height / 2;
 
     // Configure the plot
     const gridWidth =
       layout.innerWidth -
-      valueAxisWidth -
+      yAxisWidth -
       layout.borderLeftWidth -
       layout.borderRightWidth;
 
     // Configure the X axis
-    const categoryAxisStyle = resolveStyle(styles.categoryAxis, context.layout);
-    const categoryAxisLineWidth = 1;
-    const categoryAxisLabelWidth = gridWidth / categories.length;
-    const categoryAxisMetrics = computeMaxTextMetrics(
+    const xAxisStyle = resolveStyle(styles.xAxis, context.layout);
+    const xAxisLineWidth = 1;
+    const xAxisLabelWidth = gridWidth / categories.length;
+    const xAxisMetrics = computeMaxTextMetrics(
       categories,
-      categoryAxisStyle,
-      categoryAxisLabelWidth
+      xAxisStyle,
+      xAxisLabelWidth
     );
-    const categoryAxisHeight =
-      categoryAxisMetrics.height +
-      categoryAxisStyle.marginTop +
-      categoryAxisStyle.marginBottom +
-      categoryAxisLineWidth;
+    const xAxisHeight =
+      xAxisMetrics.height +
+      xAxisStyle.marginTop +
+      xAxisStyle.marginBottom +
+      xAxisLineWidth;
 
     // Setup base configurations
     const seriesBaseConfig = {
@@ -262,8 +262,8 @@ export default class BarChartModifier extends AbstractChartModifier {
         max: valueAxisScale === 'shared' ? data.maxValue : 'dataMax',
         axisLabel: {
           // margin between the axis label and the axis line
-          margin: valueAxisStyle.marginRight,
-          ...this.generateAxisLabelConfig(layout, valueAxisStyle),
+          margin: yAxisStyle.marginRight,
+          ...this.generateAxisLabelConfig(layout, yAxisStyle),
         },
       },
     ];
@@ -276,10 +276,10 @@ export default class BarChartModifier extends AbstractChartModifier {
           // Ensure every category is shown on the axis
           interval: 0,
           overflow: 'break',
-          width: categoryAxisLabelWidth,
+          width: xAxisLabelWidth,
           // margin between the axis label and the axis line
-          margin: categoryAxisStyle.marginTop,
-          ...this.generateAxisLabelConfig(layout, categoryAxisStyle),
+          margin: xAxisStyle.marginTop,
+          ...this.generateAxisLabelConfig(layout, xAxisStyle),
         },
       },
     ];
@@ -288,10 +288,10 @@ export default class BarChartModifier extends AbstractChartModifier {
       grid: [
         {
           // Not sure why the 1px adjustment is needed to `x`, but it is
-          x: layout.innerX + valueAxisWidth - 1,
-          y: layout.innerY + valueAxisOverflow,
+          x: layout.innerX + yAxisWidth - 1,
+          y: layout.innerY + yAxisOverflow,
           width: gridWidth,
-          height: layout.innerHeight - categoryAxisHeight - valueAxisOverflow,
+          height: layout.innerHeight - xAxisHeight - yAxisOverflow,
         },
       ],
       yAxis: valueAxisConfig,

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -77,6 +77,12 @@ const setItemColor = (colorMap, item, color) =>
  *   `right`, `topLeft`, `topRight`, `bottomLeft`, `bottomRight`, `leftTop`,
  *   `leftBottom`, `rightTop`, `rightBottom`
  *
+ * `legendOrientation`
+ * : Which orientation to render the legend: `horizontal`, `vertical` or `auto`
+ *   (default), where `auto` renders the legend horizontally when positioned
+ *   on the top or bottom of the chart, and vertically when positioned on the
+ *   left or right of the chart
+ *
  * `colorMap`
  * : A hash that maps series names to the colors to use for the data items in
  *   those series

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -2,6 +2,7 @@ import computeStatistic from '../utils/data/compute-statistic';
 import getSeriesData from '../utils/data/get-series-data';
 import getSeriesTotals from '../utils/data/get-series-totals';
 import getUniqueDatasetValues from '../utils/data/get-unique-dataset-values';
+import rotateDataSeries from '../utils/data/rotate-data-series';
 import computeMaxTextMetrics from '../utils/layout/compute-max-text-metrics';
 import computeTextMetrics from '../utils/layout/compute-text-metrics';
 import resolveStyle from '../utils/style/resolve-style';
@@ -159,10 +160,11 @@ export default class BarChartModifier extends AbstractChartModifier {
       // If grouped or stacked, render multple series on a single chart rather
       // than one chart per series
       series:
-        this.isGroupedVariant(args.variant) ||
         this.isStackedVariant(args.variant)
-          ? [{ data: context.series }]
-          : context.series,
+          ? [{ data: rotateDataSeries(context.series, 'name', 'value') }]
+          : this.isGroupedVariant(args.variant)
+            ? [{ data: context.series }]
+            : context.series,
     };
   }
 

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -34,6 +34,10 @@ const setItemColor = (colorMap, item, color) =>
  * : CSS properties for the title for the entire chart including color, font,
  *   background color, border and alignment.
  *
+ * `legendStyle`
+ * : CSS properties for the chart legend including color, font, background
+ *   color, border and alignment.
+ *
  * `cellStyle`
  * : CSS properties defining the style for individual plots when rendering more
  *   than one series

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -11,6 +11,16 @@ import AbstractChartModifier from './abstract-chart';
 // TODO: Import only the required components to keep the bundle size small. See
 //       https://echarts.apache.org/handbook/en/basics/import/ [twl 6.Apr.22]
 
+const setItemColor = (colorMap, item, color) =>
+  !colorMap?.[color]
+    ? item
+    : {
+        ...item,
+        itemStyle: {
+          color: colorMap[color],
+        },
+      };
+
 /**
  * Renders one or more bar charts.
  *
@@ -66,6 +76,10 @@ import AbstractChartModifier from './abstract-chart';
  * : Whether and where to display a legend: `none`, `top`, `bottom`, `left`,
  *   `right`, `topLeft`, `topRight`, `bottomLeft`, `bottomRight`, `leftTop`,
  *   `leftBottom`, `rightTop`, `rightBottom`
+ *
+ * `colorMap`
+ * : A hash that maps series names to the colors to use for the data items in
+ *   those series
  */
 export default class BarChartModifier extends AbstractChartModifier {
   get defaultStyles() {
@@ -344,7 +358,10 @@ export default class BarChartModifier extends AbstractChartModifier {
         : series.data.map((info) => ({
             ...seriesBaseConfig,
             name: info.label,
-            data: getSeriesData(info.data, categories, 'name', 'value'),
+            data: info.data.map((item) => ({
+              ...item,
+              ...setItemColor(args.colorMap, item, info.label),
+            })),
             ...(isStackedVariant && {
               stack: 'total',
             }),

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -61,6 +61,11 @@ import AbstractChartModifier from './abstract-chart';
  * `orientation`
  * : Which orientation to render the value axes: `vertical` (default) or
  *   `horizontal`
+ *
+ * `legend`
+ * : Whether and where to display a legend: `none`, `top`, `bottom`, `left`,
+ *   `right`, `topLeft`, `topRight`, `bottomLeft`, `bottomRight`, `leftTop`,
+ *   `leftBottom`, `rightTop`, `rightBottom`
  */
 export default class BarChartModifier extends AbstractChartModifier {
   get defaultStyles() {
@@ -166,6 +171,21 @@ export default class BarChartModifier extends AbstractChartModifier {
             ? [{ data: context.series }]
             : context.series,
     };
+  }
+
+  /**
+   * Returns the labels for the legend.
+   */
+  getLegendLabels(series, args) {
+    if (
+      !this.isStackedVariant(args.variant) &&
+      !this.isGroupedVariant(args.variant)
+    ) {
+      return super.getLegendLabels(series, args);
+    }
+
+    // Grouped and stacked datasets may have a dummy root node
+    return series[0].data.map((info) => info.label ?? info.name);
   }
 
   /**

--- a/packages/ember-apache-echarts/src/modifiers/time-series-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/time-series-chart.js
@@ -1,6 +1,6 @@
 import AbstractChartModifier from './abstract-chart';
 import countBy from 'lodash/countBy';
-import createLookup from '../utils/create-lookup';
+import getSeriesData from '../utils/data/get-series-data';
 import { tracked } from '@glimmer/tracking';
 
 // TODO: Import only the required components to keep the bundle size small. See
@@ -26,12 +26,6 @@ function getCategories(dataset, property) {
   }
 
   return Array.from(result.values()).sort();
-}
-
-function getSeriesData(data, categories, categoryProperty, valueProperty) {
-  const lookup = createLookup(data, categoryProperty, valueProperty);
-
-  return categories.map((category) => lookup[category]);
 }
 
 /**

--- a/packages/ember-apache-echarts/src/utils/data/get-series-data.js
+++ b/packages/ember-apache-echarts/src/utils/data/get-series-data.js
@@ -1,0 +1,24 @@
+import createLookup from '../create-lookup';
+
+/**
+ * Returns the data values from the `data` array.
+ *
+ * @param {object[]} data             An array of data objects
+ * @param {string[]} categories       An array of category names
+ * @param {string}   categoryProperty The name of the property in each data
+ *                                    object that represents the category
+ * @param {string}   valueProperty    The name of the property in each data
+ *                                    object that represents the value
+
+ * @return {number[]} An array of data values
+ */
+export default function getSeriesData(
+  data,
+  categories,
+  categoryProperty,
+  valueProperty
+) {
+  const lookup = createLookup(data, categoryProperty, valueProperty);
+
+  return categories.map((category) => lookup[category]);
+}

--- a/packages/ember-apache-echarts/src/utils/data/get-series-data.js
+++ b/packages/ember-apache-echarts/src/utils/data/get-series-data.js
@@ -9,7 +9,7 @@ import createLookup from '../create-lookup';
  *                                    object that represents the category
  * @param {string}   valueProperty    The name of the property in each data
  *                                    object that represents the value
-
+ *
  * @return {number[]} An array of data values
  */
 export default function getSeriesData(

--- a/packages/ember-apache-echarts/src/utils/data/get-series-totals.js
+++ b/packages/ember-apache-echarts/src/utils/data/get-series-totals.js
@@ -1,0 +1,35 @@
+import flatten from 'lodash/flatten';
+import transform from 'lodash/transform';
+
+/**
+ * Compute the sum of all values in the series in `data` for each category in
+ * `categories`.
+ *
+ * @param {object[]} data             An array of data objects
+ * @param {string[]} categories       An array of category names
+ * @param {string}   categoryProperty The name of the property in each data
+ *                                    object that represents the category
+ * @param {string}   valueProperty    The name of the property in each data
+ *                                    object that represents the value
+
+ * @return {number[]} An array of the sums for the values for each category
+ */
+export default function getSeriesTotals(
+  data,
+  categories,
+  categoryProperty,
+  valueProperty
+) {
+  const allData = flatten(data.map((info) => info.data));
+
+  return Object.values(
+    transform(
+      allData,
+      (totals, item) => {
+        totals[item[categoryProperty]] =
+          (totals[item[categoryProperty]] ?? 0) + item[valueProperty];
+      },
+      {}
+    )
+  );
+}

--- a/packages/ember-apache-echarts/src/utils/data/rotate-data-series.js
+++ b/packages/ember-apache-echarts/src/utils/data/rotate-data-series.js
@@ -18,19 +18,20 @@ import getUniqueDatasetValues from './get-unique-dataset-values';
  *
  * @return {object[]} data An array of data objects
  */
-const rotateDataSeries = (data, categoryProperty, valueProperty) => (
-  getUniqueDatasetValues(data, categoryProperty).map(label => ({
+const rotateDataSeries = (data, categoryProperty, valueProperty) =>
+  getUniqueDatasetValues(data, categoryProperty).map((label) => ({
     label,
     data: data.map((series) => {
-      const item = series.data.find(item => item[categoryProperty] === label);
+      const item = series.data.find((item) => item[categoryProperty] === label);
 
-      return !item ? undefined : ({
-        [categoryProperty]: series.label,
-        [valueProperty]: item[valueProperty],
-        ...omit(series, 'data', 'label'),
-      });
+      return !item
+        ? undefined
+        : {
+            [categoryProperty]: series.label,
+            [valueProperty]: item[valueProperty],
+            ...omit(series, 'data', 'label'),
+          };
     }),
-  }))
-);
+  }));
 
 export default rotateDataSeries;

--- a/packages/ember-apache-echarts/src/utils/data/rotate-data-series.js
+++ b/packages/ember-apache-echarts/src/utils/data/rotate-data-series.js
@@ -1,0 +1,36 @@
+import omit from 'lodash/omit';
+import getUniqueDatasetValues from './get-unique-dataset-values';
+
+/**
+ * Rotates the data series so the data elements in each series become series
+ * themselves and the data series become elements within those series.
+ *
+ * Essentially, if `data` represents a 2-dimensional data set with rows and
+ * columns that has been rendered into a hierarchy where each row is a series
+ * and the data within each series are the columns in those rows, this swaps the
+ * rows for the columns.
+ *
+ * @param {object[]} data             An array of data objects
+ * @param {string}   categoryProperty The name of the property in each data
+ *                                    object that represents the category
+ * @param {string}   valueProperty    The name of the property in each data
+ *                                    object that represents the value
+ *
+ * @return {object[]} data An array of data objects
+ */
+const rotateDataSeries = (data, categoryProperty, valueProperty) => (
+  getUniqueDatasetValues(data, categoryProperty).map(label => ({
+    label,
+    data: data.map((series) => {
+      const item = series.data.find(item => item[categoryProperty] === label);
+
+      return !item ? undefined : ({
+        [categoryProperty]: series.label,
+        [valueProperty]: item[valueProperty],
+        ...omit(series, 'data', 'label'),
+      });
+    }),
+  }))
+);
+
+export default rotateDataSeries;

--- a/packages/ember-apache-echarts/src/utils/layout/compute-max-text-metrics.js
+++ b/packages/ember-apache-echarts/src/utils/layout/compute-max-text-metrics.js
@@ -1,16 +1,17 @@
 import computeTextMetrics from './compute-text-metrics';
 
 /**
- * Returns the width and height required to render the strings contained in
- * `array` when rendered with `style`. If `maxWidth` is set, then wraps text
+ * Returns the width and height required to render each of the strings contained
+ * in `array` when rendered with `style`. If `maxWidth` is set, then wraps text
  * that may be longer.
  *
  * @param {string[]} array    An array of strings to render as text
  * @param {object}   style    An object containing CSS properties
  * @param {number}   maxWidth The maximum width to render the text within
  *
- * @return {object} An object specifying the `width` and `height` that will
- *                  contain all of the strings in `array` when rendered
+ * @return {object} An object specifying the `width` and `height` that is
+ *                  sufficient to contain each of the strings in `array` when
+ *                  rendered
  */
 const computeMaxTextMetrics = (array, style, maxWidth) =>
   array.reduce(

--- a/packages/test-app/app/components/chart-bar-example.hbs
+++ b/packages/test-app/app/components/chart-bar-example.hbs
@@ -39,6 +39,18 @@
   @noDataText="No data"
 />
 
+<h3>Stacked Horizontal</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="stackedBar"
+  @orientation="horizontal"
+  @cellStyle={{hash border="solid 1px rgb(229, 231, 235)" margin=2}}
+  @series={{this.seriesData}}
+  @noDataText="No data"
+/>
+
 <h2>Line Charts</h2>
 
 <h3>Simple</h3>

--- a/packages/test-app/app/components/chart-bar-example.hbs
+++ b/packages/test-app/app/components/chart-bar-example.hbs
@@ -16,7 +16,7 @@
   @height="200"
   @series={{this.seriesData}}
   @noDataText="No data"
-  @yAxisScale="shared"
+  @valueAxisScale="shared"
 />
 
 <h3>Grouped</h3>
@@ -59,7 +59,7 @@
   @variant="line"
   @series={{this.seriesData}}
   @noDataText="No data"
-  @yAxisScale="shared"
+  @valueAxisScale="shared"
 />
 
 <h2>Area Charts</h2>
@@ -82,7 +82,7 @@
   @variant="area"
   @series={{this.seriesData}}
   @noDataText="No data"
-  @yAxisScale="shared"
+  @valueAxisScale="shared"
 />
 
 <h3>Stacked</h3>

--- a/packages/test-app/app/components/chart-bar-example.hbs
+++ b/packages/test-app/app/components/chart-bar-example.hbs
@@ -38,3 +38,59 @@
   @series={{this.seriesData}}
   @noDataText="No data"
 />
+
+<h2>Line Charts</h2>
+
+<h3>Simple</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="line"
+  @data={{this.chartData}}
+  @noDataText="No data"
+/>
+
+<h3>Series</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="line"
+  @series={{this.seriesData}}
+  @noDataText="No data"
+  @yAxisScale="shared"
+/>
+
+<h2>Area Charts</h2>
+
+<h3>Simple</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="area"
+  @data={{this.chartData}}
+  @noDataText="No data"
+/>
+
+<h3>Series</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="area"
+  @series={{this.seriesData}}
+  @noDataText="No data"
+  @yAxisScale="shared"
+/>
+
+<h3>Stacked</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="stackedArea"
+  @series={{this.seriesData}}
+  @noDataText="No data"
+/>

--- a/packages/test-app/app/components/chart-bar-example.hbs
+++ b/packages/test-app/app/components/chart-bar-example.hbs
@@ -1,0 +1,40 @@
+<h2>Bar Charts</h2>
+
+<h3>Simple</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @data={{this.chartData}}
+  @noDataText="No data"
+/>
+
+<h3>Series</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @series={{this.seriesData}}
+  @noDataText="No data"
+  @yAxisScale="shared"
+/>
+
+<h3>Grouped</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="groupedBar"
+  @series={{this.seriesData}}
+  @noDataText="No data"
+/>
+
+<h3>Stacked</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="stackedBar"
+  @series={{this.seriesData}}
+  @noDataText="No data"
+/>

--- a/packages/test-app/app/components/chart-bar-example.hbs
+++ b/packages/test-app/app/components/chart-bar-example.hbs
@@ -27,6 +27,7 @@
   @variant="groupedBar"
   @series={{this.seriesData}}
   @noDataText="No data"
+  @legend="bottom"
 />
 
 <h3>Stacked</h3>
@@ -37,6 +38,7 @@
   @variant="stackedBar"
   @series={{this.seriesData}}
   @noDataText="No data"
+  @legend="right"
 />
 
 <h3>Stacked Horizontal</h3>
@@ -49,6 +51,7 @@
   @cellStyle={{hash border="solid 1px rgb(229, 231, 235)" margin=2}}
   @series={{this.seriesData}}
   @noDataText="No data"
+  @legend="bottom"
 />
 
 <h2>Line Charts</h2>

--- a/packages/test-app/app/components/chart-bar-example.js
+++ b/packages/test-app/app/components/chart-bar-example.js
@@ -1,0 +1,72 @@
+import Component from '@glimmer/component';
+
+export default class ChartBarExample extends Component {
+  chartData = [
+    {
+      name: 'sent',
+      value: 2,
+    },
+    {
+      name: 'draft',
+      value: 1,
+    },
+    {
+      name: 'rejected',
+      value: 13,
+    },
+  ];
+
+  seriesData = [
+    {
+      label: 'Today',
+      data: [
+        {
+          name: 'sent',
+          value: 2,
+        },
+        {
+          name: 'draft',
+          value: 1,
+        },
+        {
+          name: 'rejected',
+          value: 13,
+        },
+        ],
+    },
+    {
+      label: 'Yesterday',
+      data: [
+        {
+          name: 'sent',
+          value: 4,
+        },
+        {
+          name: 'draft',
+          value: 2,
+        },
+        {
+          name: 'rejected',
+          value: 5,
+        },
+        ],
+    },
+    {
+      label: 'Last Week',
+      data: [
+        {
+          name: 'sent',
+          value: 42,
+        },
+        {
+          name: 'draft',
+          value: 5,
+        },
+        {
+          name: 'rejected',
+          value: 21,
+        },
+        ],
+    },
+  ]
+}

--- a/packages/test-app/app/components/chart-bar-example.js
+++ b/packages/test-app/app/components/chart-bar-example.js
@@ -32,7 +32,7 @@ export default class ChartBarExample extends Component {
           name: 'rejected',
           value: 13,
         },
-        ],
+      ],
     },
     {
       label: 'Yesterday',
@@ -49,7 +49,7 @@ export default class ChartBarExample extends Component {
           name: 'rejected',
           value: 5,
         },
-        ],
+      ],
     },
     {
       label: 'Last Week',
@@ -66,7 +66,7 @@ export default class ChartBarExample extends Component {
           name: 'rejected',
           value: 21,
         },
-        ],
+      ],
     },
-  ]
+  ];
 }

--- a/packages/test-app/app/components/chart-pie-example.hbs
+++ b/packages/test-app/app/components/chart-pie-example.hbs
@@ -18,3 +18,13 @@
   @data={{this.chartData}}
   @noDataText="No data"
 />
+
+<h3>Series Donut</h3>
+<Chart::Pie
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="donut"
+  @series={{this.seriesData}}
+  @noDataText="No data"
+/>

--- a/packages/test-app/app/components/chart-pie-example.hbs
+++ b/packages/test-app/app/components/chart-pie-example.hbs
@@ -1,4 +1,6 @@
-<h2>Simple Pie Chart</h2>
+<h2>Pie &amp; Donut Charts</h2>
+
+<h3>Simple Pie</h3>
 <Chart::Pie
   class="border"
   @width="100%"
@@ -7,7 +9,7 @@
   @noDataText="No data"
 />
 
-<h2>Simple Donut Chart</h2>
+<h3>Simple Donut</h3>
 <Chart::Pie
   class="border"
   @width="100%"

--- a/packages/test-app/app/components/chart-pie-example.js
+++ b/packages/test-app/app/components/chart-pie-example.js
@@ -15,4 +15,58 @@ export default class ChartPieExample extends Component {
       value: 13,
     },
   ];
+
+  seriesData = [
+    {
+      label: 'Today',
+      data: [
+        {
+          name: 'sent',
+          value: 2,
+        },
+        {
+          name: 'draft',
+          value: 1,
+        },
+        {
+          name: 'rejected',
+          value: 13,
+        },
+        ],
+    },
+    {
+      label: 'Yesterday',
+      data: [
+        {
+          name: 'sent',
+          value: 4,
+        },
+        {
+          name: 'draft',
+          value: 2,
+        },
+        {
+          name: 'rejected',
+          value: 5,
+        },
+        ],
+    },
+    {
+      label: 'Last Week',
+      data: [
+        {
+          name: 'sent',
+          value: 42,
+        },
+        {
+          name: 'draft',
+          value: 5,
+        },
+        {
+          name: 'rejected',
+          value: 21,
+        },
+        ],
+    },
+  ]
 }

--- a/packages/test-app/app/components/chart-pie-example.js
+++ b/packages/test-app/app/components/chart-pie-example.js
@@ -32,7 +32,7 @@ export default class ChartPieExample extends Component {
           name: 'rejected',
           value: 13,
         },
-        ],
+      ],
     },
     {
       label: 'Yesterday',
@@ -49,7 +49,7 @@ export default class ChartPieExample extends Component {
           name: 'rejected',
           value: 5,
         },
-        ],
+      ],
     },
     {
       label: 'Last Week',
@@ -66,7 +66,7 @@ export default class ChartPieExample extends Component {
           name: 'rejected',
           value: 21,
         },
-        ],
+      ],
     },
-  ]
+  ];
 }

--- a/packages/test-app/app/templates/application.hbs
+++ b/packages/test-app/app/templates/application.hbs
@@ -1,3 +1,4 @@
 <h2 id="title">Welcome to ember-apache-echarts</h2>
 
 <ChartPieExample />
+<ChartBarExample />

--- a/packages/test-app/app/templates/application.hbs
+++ b/packages/test-app/app/templates/application.hbs
@@ -1,4 +1,4 @@
-<h2 id="title">Welcome to ember-apache-echarts</h2>
+<h1 id="title">Welcome to ember-apache-echarts</h1>
 
 <ChartPieExample />
 <ChartBarExample />


### PR DESCRIPTION
Enhance the bar chart with several new features, plus other minor style fixes and documentation.

## Features

### New Arguments

`variant`
: How to render the data elements within this chart: `bar` (default), `line`, `area`, `groupedBar`, `stackedBar` and `stackedArea`

`orientation`
: Which direction to render the value axis: `vertical` (default), `horizontal`

`legend` 
: Where to render a legend: `none` (default), `top`, `bottom`, `left`, `right`, `topLeft`, `topRight`, `bottomLeft`, `bottomRight`, `leftTop`, `leftBottom`, `rightTop`, `rightBottom`

`legendOrientation`
: Which orientation to render the legend: `auto` (default—horizontally if legend on top or bottom, vertically if legend on left or right), `horizontal`, `vertical`

`colorMap`
: A hash that maps series names to the colors to use for the data items in those series

`legendStyle`
: CSS properties for the chart legend including color, font, background color, border and alignment

`xAxisStyle`
: CSS properties defining the style for horizontal X axis, regardless of the value of `orientation`

`yAxisStyle`
: CSS properties defining the style for vertical Y axis, regardless of the value of `orientation`

### Renamed Arguments

`xAxisScale` -> `categoryAxisScale`
`yAxisScale` -> `valueAxisScale`
: Whether to use a shared axis for all plots that accounts for the data across all series, or use a separate axis for each plot that only uses that plot's data. Valid values are: `shared`, `separate`

## Bug Fixes

- Made `sans-serif` the fallback font if `Montserrat` is not available

