### PR TITLE
Add time axis & fix rendering issues

### DIFF
--- a/packages/ember-apache-echarts/package.json
+++ b/packages/ember-apache-echarts/package.json
@@ -87,6 +87,7 @@
       "./modifiers/abstract-chart.js": "./dist/_app_/modifiers/abstract-chart.js",
       "./modifiers/bar-chart.js": "./dist/_app_/modifiers/bar-chart.js",
       "./modifiers/pie-chart.js": "./dist/_app_/modifiers/pie-chart.js",
+      "./utils/chart/parse-axis-label.js": "./dist/_app_/utils/chart/parse-axis-label.js",
       "./utils/create-lookup.js": "./dist/_app_/utils/create-lookup.js",
       "./utils/data/compute-statistic.js": "./dist/_app_/utils/data/compute-statistic.js",
       "./utils/data/get-series-data.js": "./dist/_app_/utils/data/get-series-data.js",

--- a/packages/ember-apache-echarts/package.json
+++ b/packages/ember-apache-echarts/package.json
@@ -101,6 +101,7 @@
       "./utils/layout/layout-cells.js": "./dist/_app_/utils/layout/layout-cells.js",
       "./utils/merge-at-paths.js": "./dist/_app_/utils/merge-at-paths.js",
       "./utils/merge-at.js": "./dist/_app_/utils/merge-at.js",
+      "./utils/on-element-resize.js": "./dist/_app_/utils/on-element-resize.js",
       "./utils/style/format-css-style-value.js": "./dist/_app_/utils/style/format-css-style-value.js",
       "./utils/style/parse-css-style-value.js": "./dist/_app_/utils/style/parse-css-style-value.js",
       "./utils/style/resolve-style.js": "./dist/_app_/utils/style/resolve-style.js",

--- a/packages/ember-apache-echarts/src/components/chart/bar.hbs
+++ b/packages/ember-apache-echarts/src/components/chart/bar.hbs
@@ -1,4 +1,7 @@
-<div {{did-insert this.setup}}>
+<div
+  {{did-insert this.setup}}
+  {{style width="100%" height="100%"}}
+>
   <div
     ...attributes
     {{style width=(css-size @width "100%") height=(css-size @height 400)}}

--- a/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
@@ -101,6 +101,10 @@ export default class AbstractChartModifier extends Modifier {
   createChart(element, chartArgs) {
     const chart = echarts.init(element, null, { renderer: 'canvas' });
 
+    // Initialize the chart model using default options so charts that need to
+    // access the locale via the model while being built can do so
+    chart.setOption({});
+
     // Add a `handle` method that ensures only one event listener can be
     // attached at the same time. This prevents mistakes when coding new charts
     // of forgetting to `off` an event during a reconfigure and then having

--- a/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/abstract-chart.js
@@ -404,8 +404,10 @@ export default class AbstractChartModifier extends Modifier {
 
     return {
       ...context.layout,
-      height: context.layout.height - textHeight,
-      y: context.layout.y + textHeight,
+      cell: {
+        ...context.layout.cell,
+        yOffset: textHeight,
+      },
     };
   }
 

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -978,7 +978,7 @@ export default class BarChartModifier extends AbstractChartModifier {
       // Not sure why the 1px adjustment is needed to `x`, but it is
       x: layout.innerX + yAxisInfo.width - 1,
       y: layout.innerY + yAxisInfo.heightOverflow,
-      width: xAxisInfo.width,
+      width: xAxisInfo.width - xAxisInfo.widthOverflow,
       height: layout.innerHeight - xAxisInfo.height - yAxisInfo.heightOverflow,
     };
 
@@ -1297,12 +1297,16 @@ export default class BarChartModifier extends AbstractChartModifier {
     const labelMetrics = computeMaxTextMetrics(labels, style, maxLabelWidth);
     const height =
       labelMetrics.height + style.marginTop + style.marginBottom + lineWidth;
+    const widthOverflow = isHorizontal
+      ? computeTextMetrics(`${labels[labels.length - 1]}`, style).width / 2
+      : 0;
 
     return {
       width,
       height,
       labelMetrics,
       maxLabelWidth,
+      widthOverflow,
     };
   }
 }

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -1352,9 +1352,7 @@ export default class BarChartModifier extends AbstractChartModifier {
       layout.borderLeftWidth -
       layout.borderRightWidth;
     const lineWidth = isHorizontal ? 0 : 1;
-    // 10 is arbitrary number here, since we don't know how many divisions the
-    // chart will create if the X axis is a value axis
-    const maxLabelWidth = width / (isHorizontal ? 10 : maxLabelCount);
+    const maxLabelWidth = width / (isHorizontal ? ticks.length : maxLabelCount);
 
     // TODO: If we want to be precise, we should be passing in a custom style
     //       for each tick, since if a tick has a `type` of `primary`, it gets

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -863,7 +863,9 @@ export default class BarChartModifier extends AbstractChartModifier {
             valueAxisFormatter(value, 'axis', axisIndex),
         }),
         // margin between the axis label and the axis line
-        margin: valueAxisStyle.marginRight,
+        margin: isHorizontal
+          ? valueAxisStyle.marginTop
+          : valueAxisStyle.marginRight,
         ...this.generateAxisLabelConfig(layout, valueAxisStyle),
       },
     };

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -1342,8 +1342,9 @@ export default class BarChartModifier extends AbstractChartModifier {
    * Computes style and metrics about the X axis for charts that use an X axis.
    */
   computeXAxisInfo(args, layout, style, ticks, yAxisInfo, isHorizontal) {
+    const { categoryAxisMaxLabelCount, categoryAxisType } = args;
     const maxLabelCount = Math.min(
-      args.categoryAxisMaxLabelCount ?? ticks.length,
+      categoryAxisMaxLabelCount ?? ticks.length,
       ticks.length
     );
     const width =
@@ -1372,10 +1373,10 @@ export default class BarChartModifier extends AbstractChartModifier {
     // Handle when label extends past end of axis
     const lastTick = ticks[ticks.length - 1];
     const lastLabelWidth = computeTextMetrics(lastTick.label, style).width;
-    const widthOverflow = Math.max(
-      0,
-      lastLabelWidth / 2 - (width - lastTick.position * width)
-    );
+    const widthOverflow =
+      !isHorizontal && categoryAxisType !== 'time'
+        ? 0
+        : Math.max(0, lastLabelWidth / 2 - (width - lastTick.position * width));
 
     return {
       width,

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -807,11 +807,24 @@ export default class BarChartModifier extends AbstractChartModifier {
    */
   computeValueAxisTicks(context, valueInfo, axisConfig) {
     const { args } = context;
-      [valueInfo.minimum, valueInfo.maximum],
     const formatter = args.valueAxisFormatter ?? echarts.format.addCommas;
-    const scale = echarts.helper.createScale(
-      axisConfig
-    );
+    // prettier not formatting nested ternaries properly, so turn it off
+    // prettier-ignore
+    const minValue =
+      axisConfig.min == null
+        ? Math.min(0, valueInfo.minimum)
+        : axisConfig.min === 'dataMin'
+          ? valueInfo.minimum
+          : axisConfig.min;
+    // prettier not formatting nested ternaries properly, so turn it off
+    // prettier-ignore
+    const maxValue =
+      axisConfig.max == null
+        ? valueInfo.maximum
+        : axisConfig.max === 'dataMax'
+          ? valueInfo.maximum
+          : axisConfig.max;
+    const scale = echarts.helper.createScale([minValue, maxValue], axisConfig);
 
     return scale.getTicks(false).map((tick) => ({
       label: tick.value != null ? formatter(tick.value) : '',

--- a/packages/ember-apache-echarts/src/modifiers/bar-chart.js
+++ b/packages/ember-apache-echarts/src/modifiers/bar-chart.js
@@ -818,10 +818,8 @@ export default class BarChartModifier extends AbstractChartModifier {
     }
 
     const { variant, orientation, colorMap } = args;
-    const { categoryProperty = DEFAULT_CATEGORY_PROPERTY } = args;
-    const { valueProperty = DEFAULT_VALUE_PROPERTY } = args;
-    const { categoryAxisScale, categoryAxisMaxLabelCount } = args;
     const { categoryAxisType = 'category' } = args;
+    const { categoryAxisMaxLabelCount } = args;
     const { categoryAxisFormatter, valueAxisFormatter } = args;
     const { valueAxisScale, valueAxisMax } = args;
     const isHorizontal = orientation === 'horizontal';
@@ -830,7 +828,6 @@ export default class BarChartModifier extends AbstractChartModifier {
     const isStackedVariant = this.isStackedVariant(variant);
     const isGroupedOrStacked =
       this.isGroupedVariant(variant) || isStackedVariant;
-    const seriesData = isGroupedOrStacked ? series.data : [series];
 
     // Analyze the data
     const categoryInfo = this.computeCategoryInfo(series, context);

--- a/packages/ember-apache-echarts/src/utils/chart/parse-axis-label.js
+++ b/packages/ember-apache-echarts/src/utils/chart/parse-axis-label.js
@@ -1,0 +1,25 @@
+/**
+ * Parses an axis label into the label itself and its type.
+ *
+ * Specifically labels on the time axis may be formatted as `{primary|<label>}`
+ * to indicate they are a primary label and should be formatted using the
+ * primary formatting.
+ *
+ * @param {string} label A label as formatted by an axis or scale
+ *
+ * @return {object} An object containing the `label` and an optional `type`
+ */
+export default function parseAxisLabel(label) {
+  if (label.startsWith('{') && label.endsWith('}') && label.includes('|')) {
+    const [type, text] = label.substring(1, label.length - 2).split('|');
+
+    return {
+      type,
+      label: text,
+    };
+  }
+
+  return {
+    label,
+  };
+}

--- a/packages/ember-apache-echarts/src/utils/data/get-series-data.js
+++ b/packages/ember-apache-echarts/src/utils/data/get-series-data.js
@@ -1,3 +1,4 @@
+import compact from 'lodash/compact';
 import createLookup from '../create-lookup';
 
 /**
@@ -20,5 +21,5 @@ export default function getSeriesData(
 ) {
   const lookup = createLookup(data, categoryProperty, valueProperty);
 
-  return categories.map((category) => lookup[category]);
+  return compact(categories.map((category) => lookup[category]));
 }

--- a/packages/ember-apache-echarts/src/utils/data/get-unique-dataset-values.js
+++ b/packages/ember-apache-echarts/src/utils/data/get-unique-dataset-values.js
@@ -9,11 +9,16 @@
  * @return {any[]} An array of unique property values for `property`
  */
 export default function getUniqueDatasetValues(dataset, property) {
-  const result = new Set();
+  const result = new Map();
 
   for (const series of dataset) {
     for (const item of series.data) {
-      result.add(item[property]);
+      const value = item[property];
+
+      result.set(
+        typeof value?.valueOf === 'function' ? value.valueOf() : value,
+        value
+      );
     }
   }
 

--- a/packages/ember-apache-echarts/src/utils/layout/layout-cells.js
+++ b/packages/ember-apache-echarts/src/utils/layout/layout-cells.js
@@ -35,13 +35,18 @@ function computeChartLayoutInfo(context, array) {
  * @return {object} An object containing the cell layout info
  */
 function computeCellLayoutInfo(context, chart) {
+  const xOffset = context.layout.cell?.xOffset ?? 0;
+  const yOffset = context.layout.cell?.yOffset ?? 0;
+
   // Includes margin, border and padding
   let layoutSize = {
-    width: chart.width / chart.columns,
-    height: chart.height / chart.rows,
+    width: (chart.width / chart.columns) - xOffset,
+    height: (chart.height / chart.rows) - yOffset,
   };
 
   const cell = {
+    xOffset,
+    yOffset,
     ...layoutSize,
     ...resolveStyle(context.styles.cell, layoutSize),
   };
@@ -134,8 +139,9 @@ export default function layoutCells(context, array, callback) {
   return array.map((element, index) => {
     const column = index % layoutInfo.chart.columns;
     const row = Math.floor(index / layoutInfo.chart.columns);
+    const yOffset = layoutInfo.cell.yOffset ?? 0;
     const x = context.layout.x + layoutInfo.cell.width * column;
-    const y = context.layout.y + layoutInfo.cell.height * row;
+    const y = context.layout.y + (layoutInfo.cell.height + yOffset) * row;
 
     return callback(
       element,
@@ -155,7 +161,8 @@ export default function layoutCells(context, array, callback) {
           y +
           layoutInfo.cell.marginTop +
           layoutInfo.cell.borderTopWidth +
-          layoutInfo.cell.paddingTop,
+          layoutInfo.cell.paddingTop +
+          yOffset,
       },
       layoutInfo.chart,
       array

--- a/packages/ember-apache-echarts/src/utils/layout/layout-cells.js
+++ b/packages/ember-apache-echarts/src/utils/layout/layout-cells.js
@@ -40,8 +40,8 @@ function computeCellLayoutInfo(context, chart) {
 
   // Includes margin, border and padding
   let layoutSize = {
-    width: (chart.width / chart.columns) - xOffset,
-    height: (chart.height / chart.rows) - yOffset,
+    width: chart.width / chart.columns - xOffset,
+    height: chart.height / chart.rows - yOffset,
   };
 
   const cell = {

--- a/packages/ember-apache-echarts/src/utils/on-element-resize.js
+++ b/packages/ember-apache-echarts/src/utils/on-element-resize.js
@@ -1,0 +1,26 @@
+/**
+ * Watches the `element` for resize events and calls the `callback` whenever
+ * they occur.
+ *
+ * @param {HTMLElement} element  The element to watch
+ * @param {Function}    callback The function to call when the element is
+ *                               resized. Passed the `element`
+ * @param {Boolean}     onceOnly When set to `true`, only calls the `callback`
+ *                               the first time the element is resized;
+ *                               otherwise it is called every time
+ *
+ * @return {ResizeObserver} The observer used to watch for resize events
+ */
+export default function onElementResize(element, callback, onceOnly = false) {
+  const resizeObserver = new ResizeObserver(() => {
+    callback(element);
+
+    if (onceOnly) {
+      resizeObserver.disconnect();
+    }
+  });
+
+  resizeObserver.observe(element);
+
+  return resizeObserver;
+}


### PR DESCRIPTION
A bit of a catch-all PR...

First, it adds a `categoryAxisType` argument that, when set to `time`, renders the category axis using a time axis instead of a category axis. Adding `time` as an axis type into this chart type is a bit of a hack, but it’s easier than re-creating an entire new timeseries chart type that has almost the same implementation.

Two key differences between the `time` and `category` axis types are:

- Lines and areas are drawn through unspecified datetime points in the `time` axis whereas the `category` axis only draws points explicitly where the data indicates and then only connects points that are next to one another
- When the `time` axis is zoomed into, the labels will adjust based on the axis extent, whereas the labels for the `category` axis will remain fixed.

The `name` field of the data (or whichever field name is specified via the `categoryProperty` argument) should contain a valid datetime representation: a Date, a string that can be converted to a Date or a Unix timestamp.

Second, this PR fixes several issues with elements on the chart overlapping each other and the chart not rendering at the correct size due to extra space being added to the left of the Y axis or the bottom of the X axis. These only occurred with specific data sets.

Some problems fixed by this PR include:

- When the data included unusual decimal values
- When Dates were used for the category axis (including the time axis)
- When the formatted data was rendered smaller than the unformatted data would have been
- When using grouped chart variants like `groupedLine` with certain data
- When the chart used a `horizontal` orientation so the X axis was the value axis
- When multiple charts were rendered across multiple rows and included a title in each plot
- When certain maximum values were used for the `valueAxisMax` attribute

Some potential issues that represented rare edge cases that we're not currently encountering and don't expect to, and which required significant work to fix, were documented in the code as TODOs, but not fixed. Specifically:

- The Y axis may be rendered wider than it should be (so extra margin on the left side) if an explicit `valueAxisMax` is set to a value and that value is a) too close to one of the calculated ticks, b) higher in value than the calculated tick and c) has a formatted label that is wider than any other label on the axis. For more info, see the note in `computeYAxisInfo` in `bar-chart.js`.
- The X axis may be rendered a few pixels too narrow, potentially cutting off the rightmost label if a) using a time axis and b) the rightmost label is a primary tick and c) the style of the primary label tick is dramatically different than the style of the secondary ticks. This can be mitigated by giving the chart or plot itself a larger right margin (the default margin of 8px and padding of 8px should prevent this from being seen). For more info, see the note in `computeXAxisInfo` in `bar-chart.js`.

Finally, this PR makes the chart easier to drop into different CSS layouts, such as `grid` or `flex` by setting the `@height` to `100%`. The default height remains 400 for backward compatibility.