### PR TITLE
Add use of groupedLine variant to example in test-app

### DIFF
--- a/packages/test-app/app/components/chart-bar-example.hbs
+++ b/packages/test-app/app/components/chart-bar-example.hbs
@@ -1,3 +1,11 @@
+{{!
+By default, if you provide multiple series, the chart library renders those as small multiples.
+But if you want to see all series on a single chart, you can use groupedLine or groupedBar.
+If you want to show the relative contribution to the whole, then use stackedBar or stackedArea
+to show a stacked representation. groupedArea is not available for the same reason that
+stackedLine is not—while it can technically be rendered, it’s a bad data viz pattern
+that leads to misinterpretation.
+}}
 <h2>Bar Charts</h2>
 
 <h3>Simple</h3>
@@ -72,6 +80,17 @@
   @width="100%"
   @height="200"
   @variant="line"
+  @series={{this.seriesData}}
+  @noDataText="No data"
+  @valueAxisScale="shared"
+/>
+
+<h3>Grouped</h3>
+<Chart::Bar
+  class="border"
+  @width="100%"
+  @height="200"
+  @variant="groupedLine"
   @series={{this.seriesData}}
   @noDataText="No data"
   @valueAxisScale="shared"

--- a/packages/test-app/app/components/chart-bar-example.hbs
+++ b/packages/test-app/app/components/chart-bar-example.hbs
@@ -93,7 +93,6 @@ that leads to misinterpretation.
   @variant="groupedLine"
   @series={{this.seriesData}}
   @noDataText="No data"
-  @valueAxisScale="shared"
 />
 
 <h2>Area Charts</h2>


### PR DESCRIPTION
Based on question about showing multiple lines on a single chart, add `groupedLine` to the examples in the test-app

<img width="996" alt="Screenshot 2023-08-10 at 8 54 56 PM" src="https://github.com/crunchybananas/ember-apache-echarts/assets/17178/af87054f-3f24-4df1-804a-47953ec948a2">
